### PR TITLE
fix illegal/malformed utf-8

### DIFF
--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -36,7 +36,7 @@ module Fluent
       es.each do |time, record|
         record.each_pair do |k, v|
           if v.is_a?(String)
-            v.force_encoding("utf-8")
+            v.force_encoding("ISO-8859-1").encode("UTF-8")
           end
         end
 


### PR DESCRIPTION
fix illegal/malformed utf-8

source sequence is illegal/malformed utf-8, ignored error_class=JSON::GeneratorError tag="logs" record="{\"message
\"=>\"19-08-2016 11:30:43 sem altera\xE7\xF5es\"}"

it should be: "sem alterações"
