### PR TITLE
Support "warning" Severity in addition to "warn"

### DIFF
--- a/test/plugin/out_remote_syslog.rb
+++ b/test/plugin/out_remote_syslog.rb
@@ -81,4 +81,19 @@ class RemoteSyslogOutputTest < Test::Unit::TestCase
       d.feed("tag", Fluent::EventTime.now, {"message" => "foo"})
     end
   end
+
+  data("emerg", {in: "emerg", out: "emerg"})
+  data("alert", {in: "alert", out: "alert"})
+  data("crit", {in: "crit", out: "crit"})
+  data("err", {in: "err", out: "err"})
+  data("warn", {in: "warn", out: "warn"})
+  data("warning", {in: "warning", out: "warn"})
+  data("notice", {in: "notice", out: "notice"})
+  data("info", {in: "info", out: "info"})
+  data("debug", {in: "debug", out: "debug"})
+  data("wrong", {in: "wrong", out: "wrong"})
+  def test_severity_mapper(data)
+    out = Fluent::Plugin::RemoteSyslogOutput::SeverityMapper.map(data[:in])
+    assert_equal(data[:out], out)
+  end
 end


### PR DESCRIPTION
Issue: #41

We should use "warning" since "warn" is deprecated.

* https://linux.die.net/man/5/syslog.conf

As I commented in the code, I want to fix the upstream library [syslog_protocol](https://github.com/eric/syslog_protocol), but since the PR is already [there](https://github.com/eric/syslog_protocol/pull/9) and the library has not been maintained for a while.
So I temporarily fixed this on the plugin side.

To Reproduce:

```xml
  <source>
    @type sample
    tag "test"
    sample {"message":"Hello world."}
    rate 1
  </source>
  <match test.**>
    @type remote_syslog
    host "localhost"
    port 22222
    severity "warning"
    <buffer>
      flush_mode immediate
    </buffer>
  </match>
  <source>
    @type syslog
    tag "receive"
    port 22222
    bind "localhost"
  </source>
  <match receive.**>
    @type stdout
  </match>
```

Error:

```
2022-09-28 11:52:32 +0900 [warn]: #0 got unrecoverable error in primary and no secondary error_class=ArgumentError error="'warning' is not a designated severity"
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/syslog_protocol-0.9.2/lib/syslog_protocol/packet.rb:72:in `severity='
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/sender.rb:45:in `block (2 levels) in transmit'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/sender.rb:44:in `each'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/sender.rb:44:in `block in transmit'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/sender.rb:37:in `each'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/sender.rb:37:in `transmit'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/fluent-plugin-remote_syslog-1.0.0/lib/fluent/plugin/out_remote_syslog.rb:105:in `block (2 levels) in write'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/fluent-plugin-remote_syslog-1.0.0/lib/fluent/plugin/out_remote_syslog.rb:104:in `each_line'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/fluent-plugin-remote_syslog-1.0.0/lib/fluent/plugin/out_remote_syslog.rb:104:in `block in write'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/buffer/memory_chunk.rb:81:in `open'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/buffer/memory_chunk.rb:81:in `open'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/fluent-plugin-remote_syslog-1.0.0/lib/fluent/plugin/out_remote_syslog.rb:103:in `write'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:1180:in `try_flush'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:1501:in `flush_thread_run'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin/output.rb:501:in `block (2 levels) in start'
  2022-09-28 11:52:32 +0900 [warn]: #0 /home/daipom/work/fluentd/fluentd/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2022-09-28 11:52:32 +0900 [warn]: #0 bad chunk is moved to /tmp/fluent/backup/worker0/object_bcc/5e9b3da2864b66dc02914ecefd85921a.log
2022-09-28 11:52:33 +0900 [warn]: #0 got unrecoverable error in primary and no secondary error_class=ArgumentError error="'warning' is not a designated severity"
```