### PR TITLE
Add ssl_min_version and ssl_max_version params

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ $ td-agent-gem install fluent-plugin-remote_syslog
 | tls               | bool (default: false)            |                     | use TLS (tcp only)                                    |
 | ca_file           | string                           |                     | ca_file path (tls mode only)                          |
 | verify_mode       | integer                          |                     | SSL verification mode (tls mode only)                 |
+| ssl_min_version   | string                           |                     | SSL/TLS minimal version (tls mode only)               |
+| ssl_max_version   | string                           |                     | SSL/TLS maximal version (tls mode only)               |
 | packet_size       | integer (default: `1024`)        |                     | size limitation for syslog packet                     |
 | timeout           | integer                          |                     | TCP transfer timeout. if value is 0, wait forever     |
 | timeout_exception | bool (default: `false`)          |                     | if value is true, raise exception by transfer timeout |

--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -21,6 +21,8 @@ module Fluent
       config_param :tls, :bool, :default => false
       config_param :ca_file, :string, :default => nil
       config_param :verify_mode, :integer, default: nil
+      config_param :ssl_min_version, :string, :default => nil
+      config_param :ssl_max_version, :string, :default => nil
       config_param :packet_size, :size, default: 1024
       config_param :timeout, :time, default: nil
       config_param :timeout_exception, :bool, default: false
@@ -134,6 +136,8 @@ module Fluent
             program: @program,
           }
           options[:ca_file] = @ca_file if @ca_file
+          options[:ssl_min_version] = @ssl_min_version if @ssl_min_version
+          options[:ssl_max_version] = @ssl_max_version if @ssl_max_version
           options[:verify_mode] = @verify_mode if @verify_mode
           sender = RemoteSyslogSender::TcpSender.new(
             host,
@@ -161,7 +165,7 @@ module Fluent
       module SeverityMapper
         DICT = {
           # "warning" is not supported, but we should use it since "warn" is deprecated.
-          "warning" => "warn", 
+          "warning" => "warn",
         }
 
         def self.map(severity)


### PR DESCRIPTION
Introduce `ssl_min_version` and `ssl_max_version` params.

By default (both unset), the current behaviour stands ('TLSv1_2' is used as default in reproio/remote_syslog_sender).

This requires https://github.com/reproio/remote_syslog_sender/pull/6 to be merged and remote_syslog_sender to be released.

This should close #54 

