### PR TITLE
Fix exception when only host_with_port is set

### DIFF
--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -79,11 +79,11 @@ module Fluent
       def write(chunk)
         return if chunk.empty?
 
-        host = extract_placeholders(@host, chunk.metadata)
-        port = @port
-
         if @host_with_port
           host, port = extract_placeholders(@host_with_port, chunk.metadata).split(":")
+        else
+          host = extract_placeholders(@host, chunk.metadata)
+          port = @port
         end
 
         host_with_port = "#{host}:#{port}"


### PR DESCRIPTION
If `@host` is nil, `extract_placeholders` fails.